### PR TITLE
Feat: Allow custom TwoWire object for multi-bus support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,15 @@ Examples | Erriez BMP280/BME280 sensor:
 #define SEA_LEVEL_PRESSURE_HPA      1026.25
 
 // Create BMX280 object I2C address 0x76 or 0x77
+// This uses the default Wire object
 ErriezBMX280 bmx280 = ErriezBMX280(0x76);
+
+// To use a different I2C bus (e.g., Wire1 on ESP32 or Due):
+// 1. Make sure your board supports Wire1.
+// 2. Include Wire1 if necessary (usually included with Wire.h).
+// 3. Initialize Wire1 in setup(): Wire1.begin(); Wire1.setClock(400000);
+// 4. Create the object passing the Wire1 instance:
+// ErriezBMX280 bmx280_on_wire1 = ErriezBMX280(0x76, &Wire1);
 
 
 void setup()
@@ -89,11 +97,15 @@ void setup()
     }
     Serial.println(F("\nErriez BMP280/BMX280 example"));
 
-    // Initialize I2C bus
+    // Initialize the default I2C bus
     Wire.begin();
     Wire.setClock(400000);
 
-    // Initialize sensor
+    // If using Wire1, initialize it here:
+    // Wire1.begin(); // Add SDA/SCL pins for ESP32 if needed
+    // Wire1.setClock(400000);
+
+    // Initialize sensor (use the correct object, e.g., bmx280 or bmx280_on_wire1)
     while (!bmx280.begin()) {
         Serial.println(F("Error: Could not detect sensor"));
         delay(3000);
@@ -116,27 +128,23 @@ void setup()
 
 void loop()
 {
-    Serial.print(F("Temperature: "));
-    Serial.print(bmx280.readTemperature());
-    Serial.println(" C");
+    // Read sensor data using the correct object (e.g., bmx280 or bmx280_on_wire1)
+    float temperature = bmx280.readTemperature();
+    float pressure = bmx280.readPressure();
+    float altitude = bmx280.readAltitude(SEA_LEVEL_PRESSURE_HPA);
 
+    Serial.print(F("Temperature: ")); Serial.print(temperature); Serial.println(F(" *C"));
+    Serial.print(F("Pressure:    ")); Serial.print(pressure / 100.0); Serial.println(F(" hPa"));
+    Serial.print(F("Altitude:    ")); Serial.print(altitude); Serial.println(F(" m"));
+
+    // Read humidity if it's a BME280
     if (bmx280.getChipID() == CHIP_ID_BME280) {
-        Serial.print(F("Humidity:    "));
-        Serial.print(bmx280.readHumidity());
-        Serial.println(" %");
+        float humidity = bmx280.readHumidity();
+        Serial.print(F("Humidity:    ")); Serial.print(humidity); Serial.println(F(" %RH"));
     }
 
-    Serial.print(F("Pressure:    "));
-    Serial.print(bmx280.readPressure() / 100.0F);
-    Serial.println(" hPa");
-
-    Serial.print(F("Altitude:    "));
-    Serial.print(bmx280.readAltitude(SEA_LEVEL_PRESSURE_HPA));
-    Serial.println(" m");
-
     Serial.println();
-
-    delay(1000);
+    delay(2000);
 }
 ```
 **Output**

--- a/examples/ErriezBMX280/ErriezBMX280.ino
+++ b/examples/ErriezBMX280/ErriezBMX280.ino
@@ -39,22 +39,8 @@
 // Adjust sea level for altitude calculation
 #define SEA_LEVEL_PRESSURE_HPA      1026.25
 
-// Create BMX280 object I2C address 0x76 or 0x77 using the default Wire object
-ErriezBMX280 bmx280_default = ErriezBMX280(0x76);
-
-// Example for using a different I2C bus (e.g., Wire1 on ESP32 or Due)
-// Uncomment the following lines if your board supports Wire1
-/*
-#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_SAM_DUE)
-  // Make sure to initialize Wire1 in setup() if using it
-  // Wire1.begin(); 
-  // Wire1.setClock(400000);
-  ErriezBMX280 bmx280_wire1 = ErriezBMX280(0x76, &Wire1);
-#endif
-*/
-
-// Use this variable to interact with the sensor (change if using Wire1)
-ErriezBMX280 &bmx280 = bmx280_default;
+// Create BMX280 object I2C address 0x76 or 0x77
+ErriezBMX280 bmx280 = ErriezBMX280(0x76);
 
 
 void setup()
@@ -67,28 +53,15 @@ void setup()
     }
     Serial.println(F("\nErriez BMP280/BMX280 example"));
 
-    // Initialize the default I2C bus
+    // Initialize I2C bus
     Wire.begin();
     Wire.setClock(400000);
 
-    // If using Wire1, initialize it here (example):
-    /*
-#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_SAM_DUE)
-    // Check if you intend to use the Wire1 instance
-    // if (&bmx280 == &bmx280_wire1) { 
-    //    Wire1.begin(); // Add SDA/SCL pins for ESP32 if needed
-    //    Wire1.setClock(400000);
-    // }
-#endif
-    */
-
     // Initialize sensor
-    Serial.print(F("Initializing sensor... "));
     while (!bmx280.begin()) {
         Serial.println(F("Error: Could not detect sensor"));
         delay(3000);
     }
-    Serial.println(F("Done."));
 
     // Print sensor type
     Serial.print(F("\nSensor type: "));

--- a/examples/ErriezBMX280/ErriezBMX280.ino
+++ b/examples/ErriezBMX280/ErriezBMX280.ino
@@ -39,8 +39,22 @@
 // Adjust sea level for altitude calculation
 #define SEA_LEVEL_PRESSURE_HPA      1026.25
 
-// Create BMX280 object I2C address 0x76 or 0x77
-ErriezBMX280 bmx280 = ErriezBMX280(0x76);
+// Create BMX280 object I2C address 0x76 or 0x77 using the default Wire object
+ErriezBMX280 bmx280_default = ErriezBMX280(0x76);
+
+// Example for using a different I2C bus (e.g., Wire1 on ESP32 or Due)
+// Uncomment the following lines if your board supports Wire1
+/*
+#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_SAM_DUE)
+  // Make sure to initialize Wire1 in setup() if using it
+  // Wire1.begin(); 
+  // Wire1.setClock(400000);
+  ErriezBMX280 bmx280_wire1 = ErriezBMX280(0x76, &Wire1);
+#endif
+*/
+
+// Use this variable to interact with the sensor (change if using Wire1)
+ErriezBMX280 &bmx280 = bmx280_default;
 
 
 void setup()
@@ -53,15 +67,28 @@ void setup()
     }
     Serial.println(F("\nErriez BMP280/BMX280 example"));
 
-    // Initialize I2C bus
+    // Initialize the default I2C bus
     Wire.begin();
     Wire.setClock(400000);
 
+    // If using Wire1, initialize it here (example):
+    /*
+#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_SAM_DUE)
+    // Check if you intend to use the Wire1 instance
+    // if (&bmx280 == &bmx280_wire1) { 
+    //    Wire1.begin(); // Add SDA/SCL pins for ESP32 if needed
+    //    Wire1.setClock(400000);
+    // }
+#endif
+    */
+
     // Initialize sensor
+    Serial.print(F("Initializing sensor... "));
     while (!bmx280.begin()) {
         Serial.println(F("Error: Could not detect sensor"));
         delay(3000);
     }
+    Serial.println(F("Done."));
 
     // Print sensor type
     Serial.print(F("\nSensor type: "));

--- a/examples/ErriezBMX280_TwoSensors/ErriezBMX280_TwoSensors.ino
+++ b/examples/ErriezBMX280_TwoSensors/ErriezBMX280_TwoSensors.ino
@@ -1,0 +1,139 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Erriez, modifications (c) 2025 Your Name/Org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*!
+ * \file ErriezBMX280_TwoSensors.ino
+ * \brief Example using two BMP/BME280 sensors on separate I2C buses (Wire and Wire1) on ESP32.
+ * \details
+ *   Requires an ESP32 board.
+ *   Connect one sensor to the default I2C pins (Wire - typically GPIO 21/SDA, 22/SCL).
+ *   Connect the second sensor to the secondary I2C pins (Wire1 - typically GPIO 32/SDA, 33/SCL, check your board).
+ *   Assumes both sensors use I2C address 0x76 (possible because they are on different buses).
+ * \details
+ *     Source:          https://github.com/Erriez/ErriezBMX280
+ *     Documentation:   https://erriez.github.io/ErriezBMX280
+ */
+
+#include <Wire.h>
+#include <ErriezBMX280.h>
+
+// Adjust sea level for altitude calculation
+#define SEA_LEVEL_PRESSURE_HPA      1013.25 // Standard sea level pressure
+
+// Define I2C address (assuming both sensors use 0x76, but on different buses)
+#define BMX280_I2C_ADDR             0x76
+
+// --- Sensor 1 (using default Wire) ---
+ErriezBMX280 bmx_wire0(BMX280_I2C_ADDR); // Uses default Wire object (Wire)
+
+// --- Sensor 2 (using Wire1) ---
+// ESP32 has a second hardware I2C interface (Wire1)
+// Default pins for Wire1 might vary, check your ESP32 board documentation.
+// Common defaults are SDA=GPIO 32, SCL=GPIO 33 or SDA=GPIO 25, SCL=GPIO 26
+// You might need to specify pins in Wire1.begin(), e.g., Wire1.begin(SDA1_PIN, SCL1_PIN);
+ErriezBMX280 bmx_wire1(BMX280_I2C_ADDR, &Wire1); // Uses Wire1 object
+
+
+void setup()
+{
+    // Initialize serial
+    delay(500);
+    Serial.begin(115200);
+    while (!Serial) {
+        ;
+    }
+    Serial.println(F("\nErriez BMP280/BME280 Two Sensors Example (ESP32)"));
+
+    // --- Initialize I2C Bus 0 (Wire) ---
+    Wire.begin(); // Use default SDA/SCL pins (e.g., GPIO 21, 22)
+    Wire.setClock(400000);
+    Serial.println(F("I2C Bus 0 (Wire) Initialized."));
+
+    // --- Initialize Sensor 1 (Wire) ---
+    Serial.print(F("Initializing Sensor 1 (Wire)... "));
+    if (!bmx_wire0.begin()) {
+        Serial.println(F("Error: Could not detect Sensor 1"));
+        while(1) delay(100); // Halt on error
+    } else {
+        Serial.print(F("Detected "));
+        Serial.print((bmx_wire0.getChipID() == CHIP_ID_BME280) ? "BME280" : "BMP280");
+        Serial.println(F(" on Wire."));
+        bmx_wire0.setSampling(); // Use default settings or customize
+    }
+
+    // --- Initialize I2C Bus 1 (Wire1) ---
+    // Specify pins for Wire1 if not using defaults, e.g.:
+    // int sda1_pin = 32;
+    // int scl1_pin = 33;
+    // Wire1.begin(sda1_pin, scl1_pin);
+    Wire1.begin(); // Use default Wire1 pins for your board
+    Wire1.setClock(400000);
+    Serial.println(F("I2C Bus 1 (Wire1) Initialized."));
+
+    // --- Initialize Sensor 2 (Wire1) ---
+    Serial.print(F("Initializing Sensor 2 (Wire1)... "));
+    if (!bmx_wire1.begin()) {
+        Serial.println(F("Error: Could not detect Sensor 2"));
+         while(1) delay(100); // Halt on error
+    } else {
+        Serial.print(F("Detected "));
+        Serial.print((bmx_wire1.getChipID() == CHIP_ID_BME280) ? "BME280" : "BMP280");
+        Serial.println(F(" on Wire1."));
+        bmx_wire1.setSampling(); // Use default settings or customize
+    }
+
+    Serial.println(F("\nStarting measurements..."));
+}
+
+void loop()
+{
+    Serial.println(F("--- Sensor 1 (Wire) ---"));
+    readAndPrintSensorData(bmx_wire0);
+
+    Serial.println(F("--- Sensor 2 (Wire1) ---"));
+    readAndPrintSensorData(bmx_wire1);
+
+    Serial.println(F("--------------------------"));
+
+    delay(5000); // Wait 5 seconds between readings
+}
+
+// Helper function to read and print data from a sensor object
+void readAndPrintSensorData(ErriezBMX280 &sensor)
+{
+    float temperature = sensor.readTemperature();
+    float pressure = sensor.readPressure();
+    float altitude = sensor.readAltitude(SEA_LEVEL_PRESSURE_HPA);
+
+    Serial.print(F("  Temperature: ")); Serial.print(temperature); Serial.println(F(" *C"));
+    Serial.print(F("  Pressure:    ")); Serial.print(pressure / 100.0F); Serial.println(F(" hPa"));
+    Serial.print(F("  Altitude:    ")); Serial.print(altitude); Serial.println(F(" m"));
+
+    // Read humidity only if it's a BME280
+    if (sensor.getChipID() == CHIP_ID_BME280) {
+        float humidity = sensor.readHumidity();
+        Serial.print(F("  Humidity:    ")); Serial.print(humidity); Serial.println(F(" %RH"));
+    }
+    Serial.println();
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Erriez BMP280/BME280 sensor
-version=1.0.1
+version=1.0.2
 author=Erriez <Erriez@users.noreply.github.com>
 maintainer=Erriez <Erriez@users.noreply.github.com>
 sentence=BMP280 / BME280 sensor library for Arduino

--- a/src/ErriezBMX280.cpp
+++ b/src/ErriezBMX280.cpp
@@ -36,11 +36,23 @@
 #include "ErriezBMX280.h"
 
 /*!
- * \brief Constructor
+ * \brief Constructor using default Wire object
  * \param i2cAddr
  *      I2C address
  */
-ErriezBMX280::ErriezBMX280(uint8_t i2cAddr) : _i2cAddr(i2cAddr), _t_fine(0)
+ErriezBMX280::ErriezBMX280(uint8_t i2cAddr) : _i2cAddr(i2cAddr), _wire(&Wire), _t_fine(0)
+{
+
+}
+
+/*!
+ * \brief Constructor using custom TwoWire object
+ * \param i2cAddr
+ *      I2C address
+ * \param theWire
+ *      Pointer to TwoWire interface (e.g. &Wire or &Wire1)
+ */
+ErriezBMX280::ErriezBMX280(uint8_t i2cAddr, TwoWire *theWire) : _i2cAddr(i2cAddr), _wire(theWire), _t_fine(0)
 {
 
 }
@@ -295,13 +307,13 @@ void ErriezBMX280::setSampling(BMX280_Mode_e mode,
  */
 uint8_t ErriezBMX280::read8(uint8_t reg)
 {
-    Wire.beginTransmission(_i2cAddr);
-    Wire.write(reg);
-    if (Wire.endTransmission() != 0) {
+    _wire->beginTransmission(_i2cAddr);
+    _wire->write(reg);
+    if (_wire->endTransmission() != 0) {
         return 0;
     }
-    Wire.requestFrom(_i2cAddr, (byte)1);
-    return Wire.read();
+    _wire->requestFrom(_i2cAddr, (byte)1);
+    return _wire->read();
 }
 
 /*!
@@ -313,10 +325,10 @@ uint8_t ErriezBMX280::read8(uint8_t reg)
  */
 void ErriezBMX280::write8(uint8_t reg, uint8_t value)
 {
-    Wire.beginTransmission(_i2cAddr);
-    Wire.write(reg);
-    Wire.write(value);
-    Wire.endTransmission();
+    _wire->beginTransmission(_i2cAddr);
+    _wire->write(reg);
+    _wire->write(value);
+    _wire->endTransmission();
 }
 
 /*!
@@ -356,13 +368,13 @@ int16_t ErriezBMX280::readS16_LE(uint8_t reg)
  */
 uint16_t ErriezBMX280::read16(uint8_t reg)
 {
-    Wire.beginTransmission(_i2cAddr);
-    Wire.write(reg);
-    if (Wire.endTransmission() != 0) {
+    _wire->beginTransmission(_i2cAddr);
+    _wire->write(reg);
+    if (_wire->endTransmission() != 0) {
         return 0;
     }
-    Wire.requestFrom(_i2cAddr, (byte)2);
-    return (Wire.read() << 8) | Wire.read();
+    _wire->requestFrom(_i2cAddr, (byte)2);
+    return (_wire->read() << 8) | _wire->read();
 }
 
 /*!
@@ -376,16 +388,16 @@ uint32_t ErriezBMX280::read24(uint8_t reg)
 {
     uint32_t value;
 
-    Wire.beginTransmission(_i2cAddr);
-    Wire.write(reg);
-    Wire.endTransmission();
-    Wire.requestFrom(_i2cAddr, (byte)3);
+    _wire->beginTransmission(_i2cAddr);
+    _wire->write(reg);
+    _wire->endTransmission();
+    _wire->requestFrom(_i2cAddr, (byte)3);
 
-    value = Wire.read();
+    value = _wire->read();
     value <<= 8;
-    value |= Wire.read();
+    value |= _wire->read();
     value <<= 8;
-    value |= Wire.read();
+    value |= _wire->read();
 
     return value;
 }

--- a/src/ErriezBMX280.cpp
+++ b/src/ErriezBMX280.cpp
@@ -40,68 +40,21 @@
  * \param i2cAddr
  *      I2C address
  */
-template<typename T_WIRE> // Added template
-ErriezBMX280_T<T_WIRE>::ErriezBMX280_T(uint8_t i2cAddr) : _i2cAddr(i2cAddr), _wire(&Wire), _t_fine(0)
+ErriezBMX280::ErriezBMX280(uint8_t i2cAddr) : _i2cAddr(i2cAddr), _wire(&Wire), _t_fine(0)
 {
 
 }
 
 /*!
- * \brief Constructor using custom T_WIRE object
+ * \brief Constructor using custom TwoWire object
  * \param i2cAddr
  *      I2C address
  * \param theWire
- *      Pointer to T_WIRE interface (e.g. &Wire or &Wire1 or &SoftWire)
+ *      Pointer to TwoWire interface (e.g. &Wire or &Wire1)
  */
-template<typename T_WIRE> // Added template
-ErriezBMX280_T<T_WIRE>::ErriezBMX280_T(uint8_t i2cAddr, T_WIRE *theWire) : _i2cAddr(i2cAddr), _wire(theWire), _t_fine(0)
+ErriezBMX280::ErriezBMX280(uint8_t i2cAddr, TwoWire *theWire) : _i2cAddr(i2cAddr), _wire(theWire), _t_fine(0)
 {
 
-}
-
-/*!
- * \brief Constructor using default Wire object and auto-detecting I2C address.
- *        This constructor is intended for use when T_WIRE is compatible with the global Wire object (typically TwoWire).
- */
-template<typename T_WIRE>
-ErriezBMX280_T<T_WIRE>::ErriezBMX280_T() : _wire(&Wire), _t_fine(0)
-{
-    // Auto-detect I2C address
-    // Note: _wire is initialized to &Wire. This assumes T_WIRE is compatible (e.g., TwoWire).
-    _wire->beginTransmission(BMX280_I2C_ADDR); // Default address 0x76
-    if (_wire->endTransmission() == 0) {
-        _i2cAddr = BMX280_I2C_ADDR;
-    } else {
-        _wire->beginTransmission(BMX280_I2C_ADDR_ALT); // Alternative address 0x77
-        if (_wire->endTransmission() == 0) {
-            _i2cAddr = BMX280_I2C_ADDR_ALT;
-        } else {
-            // Fallback to default primary address if neither is found.
-            // The begin() method will ultimately determine if a sensor is truly present.
-            _i2cAddr = BMX280_I2C_ADDR;
-        }
-    }
-}
-
-/*!
- * \brief Constructor using custom T_WIRE object and auto-detecting I2C address.
- * \param theWire Pointer to T_WIRE interface (e.g. &Wire, &Wire1, or &SoftWire)
- */
-template<typename T_WIRE>
-ErriezBMX280_T<T_WIRE>::ErriezBMX280_T(T_WIRE *theWire) : _wire(theWire), _t_fine(0)
-{
-    // Auto-detect I2C address
-    _wire->beginTransmission(BMX280_I2C_ADDR); // Default address 0x76
-    if (_wire->endTransmission() == 0) {
-        _i2cAddr = BMX280_I2C_ADDR;
-    } else {
-        _wire->beginTransmission(BMX280_I2C_ADDR_ALT); // Alternative address 0x77
-        if (_wire->endTransmission() == 0) {
-            _i2cAddr = BMX280_I2C_ADDR_ALT;
-        } else {
-            _i2cAddr = BMX280_I2C_ADDR; // Fallback to default primary address
-        }
-    }
 }
 
 /*!
@@ -111,8 +64,7 @@ ErriezBMX280_T<T_WIRE>::ErriezBMX280_T(T_WIRE *theWire) : _wire(theWire), _t_fin
  * \retval false
  *      Error: No (supported) sensor detected
  */
-template<typename T_WIRE> // Added template
-bool ErriezBMX280_T<T_WIRE>::begin()
+bool ErriezBMX280::begin()
 {
     // Read chip ID
     _chipID = read8(BME280_REG_CHIPID);
@@ -150,8 +102,7 @@ bool ErriezBMX280_T<T_WIRE>::begin()
  * \return
  *      Chip ID as read with begin()
  */
-template<typename T_WIRE> // Added template
-uint8_t ErriezBMX280_T<T_WIRE>::getChipID()
+uint8_t ErriezBMX280::getChipID()
 {
     // Return chip ID
     return _chipID;
@@ -162,8 +113,7 @@ uint8_t ErriezBMX280_T<T_WIRE>::getChipID()
  * \return
  *      Temperature (float)
  */
-template<typename T_WIRE> // Added template
-float ErriezBMX280_T<T_WIRE>::readTemperature()
+float ErriezBMX280::readTemperature()
 {
     int32_t var1, var2, adc_T;
     float temperature;
@@ -191,8 +141,7 @@ float ErriezBMX280_T<T_WIRE>::readTemperature()
  * \return
  *      Pressure (float)
  */
-template<typename T_WIRE> // Added template
-float ErriezBMX280_T<T_WIRE>::readPressure()
+float ErriezBMX280::readPressure()
 {
     int64_t var1;
     int64_t var2;
@@ -234,8 +183,7 @@ float ErriezBMX280_T<T_WIRE>::readPressure()
  * \return
  *      Altitude (float)
  */
-template<typename T_WIRE> // Added template
-float ErriezBMX280_T<T_WIRE>::readAltitude(float seaLevel)
+float ErriezBMX280::readAltitude(float seaLevel)
 {
     float atmospheric = readPressure() / 100.0F;
 
@@ -248,8 +196,7 @@ float ErriezBMX280_T<T_WIRE>::readAltitude(float seaLevel)
  * \return
  *      Humidity (float)
  */
-template<typename T_WIRE> // Added template
-float ErriezBMX280_T<T_WIRE>::readHumidity()
+float ErriezBMX280::readHumidity()
 {
     int32_t v_x1_u32r;
     int32_t adc_H;
@@ -290,8 +237,7 @@ float ErriezBMX280_T<T_WIRE>::readHumidity()
 /*!
  * \brief Read coefficient registers at startup
  */
-template<typename T_WIRE> // Added template
-void ErriezBMX280_T<T_WIRE>::readCoefficients(void)
+void ErriezBMX280::readCoefficients(void)
 {
     _dig_T1 = read16_LE(BMX280_REG_DIG_T1);
     _dig_T2 = readS16_LE(BMX280_REG_DIG_T2);
@@ -332,8 +278,7 @@ void ErriezBMX280_T<T_WIRE>::readCoefficients(void)
  * \param standbyDuration
  *      See BMX280_Standby_e
  */
-template<typename T_WIRE> // Added template
-void ErriezBMX280_T<T_WIRE>::setSampling(BMX280_Mode_e mode,
+void ErriezBMX280::setSampling(BMX280_Mode_e mode,
                                BMX280_Sampling_e tempSampling,
                                BMX280_Sampling_e pressSampling,
                                BMX280_Sampling_e humSampling,
@@ -360,8 +305,7 @@ void ErriezBMX280_T<T_WIRE>::setSampling(BMX280_Mode_e mode,
  * \return
  *      8-bit register value
  */
-template<typename T_WIRE> // Added template
-uint8_t ErriezBMX280_T<T_WIRE>::read8(uint8_t reg)
+uint8_t ErriezBMX280::read8(uint8_t reg)
 {
     _wire->beginTransmission(_i2cAddr);
     _wire->write(reg);
@@ -379,8 +323,7 @@ uint8_t ErriezBMX280_T<T_WIRE>::read8(uint8_t reg)
  * \param value
  *      8-bit register value
  */
-template<typename T_WIRE> // Added template
-void ErriezBMX280_T<T_WIRE>::write8(uint8_t reg, uint8_t value)
+void ErriezBMX280::write8(uint8_t reg, uint8_t value)
 {
     _wire->beginTransmission(_i2cAddr);
     _wire->write(reg);
@@ -395,8 +338,7 @@ void ErriezBMX280_T<T_WIRE>::write8(uint8_t reg, uint8_t value)
  * \return
  *      16-bit unsigned register value in little endian
  */
-template<typename T_WIRE> // Added template
-uint16_t ErriezBMX280_T<T_WIRE>::read16_LE(uint8_t reg)
+uint16_t ErriezBMX280::read16_LE(uint8_t reg)
 {
     uint16_t value;
 
@@ -412,8 +354,7 @@ uint16_t ErriezBMX280_T<T_WIRE>::read16_LE(uint8_t reg)
  * \return
  *      16-bit signed register value in little endian
  */
-template<typename T_WIRE> // Added template
-int16_t ErriezBMX280_T<T_WIRE>::readS16_LE(uint8_t reg)
+int16_t ErriezBMX280::readS16_LE(uint8_t reg)
 {
     return (int16_t)read16_LE(reg);
 }
@@ -425,8 +366,7 @@ int16_t ErriezBMX280_T<T_WIRE>::readS16_LE(uint8_t reg)
  * \return
  *      16-bit register value
  */
-template<typename T_WIRE> // Added template
-uint16_t ErriezBMX280_T<T_WIRE>::read16(uint8_t reg)
+uint16_t ErriezBMX280::read16(uint8_t reg)
 {
     _wire->beginTransmission(_i2cAddr);
     _wire->write(reg);
@@ -444,8 +384,7 @@ uint16_t ErriezBMX280_T<T_WIRE>::read16(uint8_t reg)
  * \return
  *      24-bit register value
  */
-template<typename T_WIRE> // Added template
-uint32_t ErriezBMX280_T<T_WIRE>::read24(uint8_t reg)
+uint32_t ErriezBMX280::read24(uint8_t reg)
 {
     uint32_t value;
 

--- a/src/ErriezBMX280.h
+++ b/src/ErriezBMX280.h
@@ -37,7 +37,7 @@
 #define ERRIEZ_BME280_H_
 
 #include <Arduino.h>
-#include <Wire.h> // Re-added for TwoWire and global Wire access
+// #include <Wire.h> // Will be included by the specific wire type typically
 
 // I2C address
 #define BMX280_I2C_ADDR             0x76    //!< I2C address

--- a/src/ErriezBMX280.h
+++ b/src/ErriezBMX280.h
@@ -37,7 +37,7 @@
 #define ERRIEZ_BME280_H_
 
 #include <Arduino.h>
-#include <Wire.h>
+// #include <Wire.h> // Will be included by the specific wire type typically
 
 // I2C address
 #define BMX280_I2C_ADDR             0x76    //!< I2C address
@@ -128,15 +128,15 @@ typedef enum {
     BMX280_STANDBY_MS_1000 = 0b101          //!< 1s standby
 } BMX280_Standby_e;
 
-/*!
- * \brief BMX280 class
- */
-class ErriezBMX280
+template<typename T_WIRE> // Added template
+class ErriezBMX280_T // Renamed class
 {
 public:
     // Constructor
-    ErriezBMX280(uint8_t i2cAddr);
-    ErriezBMX280(uint8_t i2cAddr, TwoWire *theWire);
+    ErriezBMX280_T(uint8_t i2cAddr); // Remains, assumes Wire is default (T_WIRE must be TwoWire compatible)
+    ErriezBMX280_T(uint8_t i2cAddr, T_WIRE *theWire); // Changed TwoWire* to T_WIRE*
+    ErriezBMX280_T();                                // Auto-detects I2C addr, uses default Wire (T_WIRE must be TwoWire compatible)
+    ErriezBMX280_T(T_WIRE *theWire);                 // Auto-detects I2C addr, uses specified T_WIRE object
 
     // Initialization
     bool begin();
@@ -168,7 +168,7 @@ public:
 
 private:
     uint8_t _i2cAddr;   //!< I2C address
-    TwoWire* _wire;     //!< Pointer to I2C interface
+    T_WIRE* _wire;     //!< Pointer to I2C interface, changed to T_WIRE*
     uint8_t _chipID;    //!< Chip iD
     int32_t _t_fine;    //!< Temperature variable
 
@@ -196,5 +196,8 @@ private:
     // Read coefficient registers
     void readCoefficients(void);
 };
+
+// For backward compatibility with code expecting non-templated version with TwoWire
+using ErriezBMX280 = ErriezBMX280_T<TwoWire>;
 
 #endif // ERRIEZ_BMX280_H_

--- a/src/ErriezBMX280.h
+++ b/src/ErriezBMX280.h
@@ -37,7 +37,7 @@
 #define ERRIEZ_BME280_H_
 
 #include <Arduino.h>
-// #include <Wire.h> // Will be included by the specific wire type typically
+#include <Wire.h> // Re-added for TwoWire and global Wire access
 
 // I2C address
 #define BMX280_I2C_ADDR             0x76    //!< I2C address

--- a/src/ErriezBMX280.h
+++ b/src/ErriezBMX280.h
@@ -136,6 +136,7 @@ class ErriezBMX280
 public:
     // Constructor
     ErriezBMX280(uint8_t i2cAddr);
+    ErriezBMX280(uint8_t i2cAddr, TwoWire *theWire);
 
     // Initialization
     bool begin();
@@ -167,6 +168,7 @@ public:
 
 private:
     uint8_t _i2cAddr;   //!< I2C address
+    TwoWire* _wire;     //!< Pointer to I2C interface
     uint8_t _chipID;    //!< Chip iD
     int32_t _t_fine;    //!< Temperature variable
 

--- a/src/ErriezBMX280.h
+++ b/src/ErriezBMX280.h
@@ -37,7 +37,7 @@
 #define ERRIEZ_BME280_H_
 
 #include <Arduino.h>
-// #include <Wire.h> // Will be included by the specific wire type typically
+#include <Wire.h>
 
 // I2C address
 #define BMX280_I2C_ADDR             0x76    //!< I2C address
@@ -128,15 +128,15 @@ typedef enum {
     BMX280_STANDBY_MS_1000 = 0b101          //!< 1s standby
 } BMX280_Standby_e;
 
-template<typename T_WIRE> // Added template
-class ErriezBMX280_T // Renamed class
+/*!
+ * \brief BMX280 class
+ */
+class ErriezBMX280
 {
 public:
     // Constructor
-    ErriezBMX280_T(uint8_t i2cAddr); // Remains, assumes Wire is default (T_WIRE must be TwoWire compatible)
-    ErriezBMX280_T(uint8_t i2cAddr, T_WIRE *theWire); // Changed TwoWire* to T_WIRE*
-    ErriezBMX280_T();                                // Auto-detects I2C addr, uses default Wire (T_WIRE must be TwoWire compatible)
-    ErriezBMX280_T(T_WIRE *theWire);                 // Auto-detects I2C addr, uses specified T_WIRE object
+    ErriezBMX280(uint8_t i2cAddr);
+    ErriezBMX280(uint8_t i2cAddr, TwoWire *theWire);
 
     // Initialization
     bool begin();
@@ -168,7 +168,7 @@ public:
 
 private:
     uint8_t _i2cAddr;   //!< I2C address
-    T_WIRE* _wire;     //!< Pointer to I2C interface, changed to T_WIRE*
+    TwoWire* _wire;     //!< Pointer to I2C interface
     uint8_t _chipID;    //!< Chip iD
     int32_t _t_fine;    //!< Temperature variable
 
@@ -196,8 +196,5 @@ private:
     // Read coefficient registers
     void readCoefficients(void);
 };
-
-// For backward compatibility with code expecting non-templated version with TwoWire
-using ErriezBMX280 = ErriezBMX280_T<TwoWire>;
 
 #endif // ERRIEZ_BMX280_H_


### PR DESCRIPTION
## Description:

This PR enhances the ErriezBMX280 library to support using different I2C buses by allowing users to pass a custom TwoWire object (like Wire1 on ESP32 or Due) to the sensor constructor.
This change allows users with boards supporting multiple hardware I2C interfaces (like ESP32) to easily use multiple BMX280 sensors, even if they share the same I2C address, by connecting them to different buses.

## Changes:

- ErriezBMX280.h / ErriezBMX280.cpp:
Added a new constructor overload ErriezBMX280(uint8_t i2cAddr, TwoWire *theWire).
The original constructor now defaults to using the global Wire object.
Internal I2C communication now uses the provided TwoWire pointer (_wire).
- ErriezBMX280_TwoSensors.ino:
Added a new example specifically for ESP32, demonstrating how to read from two BMX280 sensors connected to Wire and Wire1 respectively.

- README.md:
Updated the documentation and example code snippet to explain how to use the new constructor for custom I2C bus selection.


